### PR TITLE
Fix update-major task

### DIFF
--- a/justfile
+++ b/justfile
@@ -3,13 +3,10 @@ release release_tag:
   git push --tags
   gh release create --generate-notes {{release_tag}} --verify-tag
 
-vmajor := ```
-  git tag |
-    sort -rV |
-    head -n 1 |
-    sed '/^\(v[0-9]\+\)\..*$/!d; s//\1/'
-```
-
 update-major:
-  git tag -f "{{vmajor}}" -m "{{vmajor}}" -s
+  vmajor=$(git tag | \
+    sort -rV | \
+    head -n 1 | \
+    sed '/^\(v[0-9]\+\)\..*$/!d; s//\1/') && \
+  git tag -f "$vmajor" -m "$vmajor" -s
   git push --tags -f


### PR DESCRIPTION
Setting `vmajor` when the `justfile` is loaded means that doing a
`release` of a new major and calling `update-major` in the same call
gets an out of date value and moves the last major tag forward to the
new major version.

```console
% just release v3.0.0 update-major
vmajor := v2
release: creates v3.0.0...
update-major: updates v2 -> v3.0.0...
```

No bueno.

We could always call them separately, but to make it less error-prone in
this way, we'll use a shell variable that is going to be up to date no
matter what.
