### PR TITLE
Avoid fetching completely PR diff as patch

### DIFF
--- a/run/src/diff.test.ts
+++ b/run/src/diff.test.ts
@@ -1,0 +1,145 @@
+import { Hunks } from "./hunk";
+import { PullRequestFile, fromPullRequestFile } from "./diff";
+
+type TestCase = {
+  name: string;
+  file: PullRequestFile;
+  expected: Hunks<{ lineNumber: number }>;
+};
+
+describe("fromPullRequestFile", () => {
+  const cases: TestCase[] = [
+    {
+      name: "Added file",
+      file: {
+        filename: ".headroom.yaml",
+        patch: [
+          "@@ -0,0 +1,52 @@",
+          "+## This is the configuration file for Headroom.",
+          "+## See https://github.com/vaclavsvejcar/headroom for more details.",
+          "+",
+          "+## Defines with which version of Headroom this configuration is compatible.",
+          "+## Headroom uses this field to detect whether your configuration doesn't need",
+          "+## any manual migration steps in case that it's older than your current Headroom",
+          "+## version. You don't need to touch this field unless explicitly stated in",
+          "+## migration guide during upgrading Headroom to new version.",
+          "+version: 0.4.3.0",
+          "+",
+          "+## Defines the behaviour how to handle license headers, possible options are:",
+          "+##",
+          "+##   - add     = (default) adds license header to files with no existing header",
+          "+##               (same as '-a|--add-headers' command line argument)",
+          "+##   - drop    = drops existing license header from without replacement",
+          "+##               (same as '-d|--drop-headers' command line argument)",
+          "+##   - replace = adds or replaces existing license header",
+          "+##               (same as '-r|--replace-headers' command line argument)",
+          "+run-mode: add",
+          "+",
+          "+## Paths to source code files (either files or directories),",
+          "+## same as '-s|--source-path=PATH' command line argument (can be used multiple",
+          "+## times for more than one path).",
+          "+source-paths:",
+          "+  - app",
+          "+  - src",
+          "+  - test",
+          "+",
+          "+## If set to 'true', Headroom tries to detect whether any VCS (like GIT) is used",
+          "+## for current project and if yes, it loads rules for ignored files and excludes",
+          "+## all source paths that matches these rules.",
+          "+exclude-ignored-paths: false",
+          "+",
+          "+## Paths to template files (either files or directories),",
+          "+## same as '-t|--template-path=PATH' command line argument (can be used multiple",
+          "+## times for more than one path).",
+          "+template-paths:",
+          "+  - headroom-templates",
+          "+",
+          "+## Variables (key-value) to replace in templates,",
+          "+## same as '-v|--variable=\"KEY=VALUE\"' command line argument (can be used",
+          "+## multiple times for more than one path).",
+          "+variables:",
+          "+  author: Patrick Brisbin",
+          "+  email: pbrisbin@gmail.com",
+          "+  project: Restyler",
+          '+  year: "2024"',
+          "+",
+          "+license-headers:",
+          "+  haskell:",
+          "+    line-comment:",
+          '+      prefixed-by: "^--"',
+        ].join("\n"),
+      },
+      expected: new Hunks(linesFromTo(1, 52)),
+    },
+    {
+      name: "Modified file",
+      file: {
+        filename: "test/SpecHelper.hs",
+        patch: [
+          "@@ -1,5 +1,13 @@ {-# LANGUAGE FieldSelectors #-}",
+          " ",
+          "+-- |",
+          "+--",
+          "+-- Module      : SpecHelper",
+          "+-- Copyright   : (c) 2024 Patrick Brisbin",
+          "+-- License     : AGPL-3",
+          "+-- Maintainer  : pbrisbin@gmail.com",
+          "+-- Stability   : experimental",
+          "+-- Portability : POSIX",
+          " module SpecHelper",
+          "   ( someRestyler",
+          " ",
+        ].join("\n"),
+      },
+      expected: new Hunks(linesFromTo(2, 9)),
+    },
+    {
+      name: "Deleted file",
+      file: {
+        filename: "LICENSE",
+        patch: [
+          "@@ -1,22 +0,0 @@",
+          "-“Commons Clause” License Condition v1.0",
+          "-",
+          "-The Software is provided to you by the Licensor under the License, as defined",
+          "-below, subject to the following condition.",
+          "-",
+          "-Without limiting other conditions in the License, the grant of rights under the",
+          "-License will not include, and the License does not grant to you, the right to",
+          "-Sell the Software.",
+          "-",
+          "-For purposes of the foregoing, “Sell” means practicing any or all of the rights",
+          "-granted to you under the License to provide to third parties, for a fee or other",
+          "-consideration (including without limitation fees for hosting or consulting/",
+          "-support services related to the Software), a product or service whose value",
+          "-derives, entirely or substantially, from the functionality of the Software. Any",
+          "-license notice or attribution required by the License must also include this",
+          "-Commons Cause License Condition notice.",
+          "-",
+          "-Software: Restyled",
+          "-",
+          "-License: MIT (https://opensource.org/licenses/MIT)",
+          "-",
+          "-Licensor: Patrick Brisbin",
+        ].join("\n"),
+      },
+      expected: new Hunks([]),
+    },
+  ];
+
+  test.each(cases)("$name", async ({ expected, file }) => {
+    const changedFile = fromPullRequestFile(file);
+    expect(changedFile.filename).toEqual(file.filename);
+    expect(changedFile.additions).toEqual(expected);
+  });
+});
+
+function linesFromTo(start: number, end: number): { lineNumber: number }[] {
+  const lines: { lineNumber: number }[] = [];
+
+  for (let i = start; i <= end; i++) {
+    lines.push({ lineNumber: i });
+  }
+
+  return lines;
+}

--- a/run/src/diff.ts
+++ b/run/src/diff.ts
@@ -1,0 +1,54 @@
+import { Hunks } from "./hunk";
+
+export interface ChangedFile {
+  filename: string;
+  additions: Hunks<AddedLine>;
+}
+
+export interface AddedLine {
+  lineNumber: number;
+}
+
+export interface PullRequestFile {
+  filename: string;
+  patch?: string;
+}
+
+const DIGITS_RE = "[1-9][0-9]*";
+const DIFF_BEGIN_RE = new RegExp(
+  `^@@ -${DIGITS_RE},${DIGITS_RE} +(?<addBegin>${DIGITS_RE}),${DIGITS_RE} @@$`,
+);
+
+export function fromPullRequestFile(file: PullRequestFile): ChangedFile {
+  const { filename, patch } = file;
+
+  if (!patch) {
+    return {
+      filename,
+      additions: new Hunks([]),
+    };
+  }
+
+  const addedLines: AddedLine[] = [];
+
+  let cursor = 0;
+
+  patch.split("\n").forEach((line) => {
+    const md = line.match(DIFF_BEGIN_RE);
+    const addBegin = md?.groups?.addBegin;
+
+    if (addBegin) {
+      cursor = parseInt(addBegin, 10); // reset begin
+    } else if (line.match(/^\+/)) {
+      addedLines.push({ lineNumber: cursor });
+      cursor += 1;
+    } else if (line.match(/^-/)) {
+      // ignore deletions
+    } else {
+      // increment on context
+      cursor += 1;
+    }
+  });
+
+  return { filename, additions: new Hunks(addedLines) };
+}

--- a/run/src/main.ts
+++ b/run/src/main.ts
@@ -102,9 +102,9 @@ async function run() {
     if (inputs.suggestions && success) {
       const resolved = await clearPriorSuggestions(client, pr);
 
-      if (pr.diff && differences) {
+      if (differences) {
         let n = 0;
-        const bases = parsePatches(pr.diff);
+        const bases = pr.changedFiles;
         const patches = parsePatches(patch);
         const ps = getSuggestions(bases, patches, resolved).map((s) => {
           if (s.skipReason) {

--- a/run/src/pull-request.ts
+++ b/run/src/pull-request.ts
@@ -61,8 +61,8 @@ export async function getPullRequest(
   }
 
   // Write PR data for restyle to use. It expects a proper API type so we can't
-  // do that with our fakePullRequest. This is also why centralize restyleArgs
-  // handling here.
+  // do that with our fakePullRequest. This is also why we centralize
+  // restyleArgs handling here.
   const pullRequestJson = temp.path({ suffix: ".json" });
   fs.writeFileSync(pullRequestJson, JSON.stringify(pr));
 

--- a/run/src/pull-request.ts
+++ b/run/src/pull-request.ts
@@ -50,7 +50,13 @@ export async function getPullRequest(
 
   if (base.tag === "known" && base.sha !== pr.head.sha) {
     core.warning(
-      `The checked out commit does not match the event PR's head. ${base.sha} != ${pr.head.sha}. Weird things may happen.`,
+      [
+        `The checked out commit does not match the event PR's head.`,
+        `${base.sha} != ${pr.head.sha}.`,
+        `This usually means you are operating on the default merge ref.`,
+        `If so, Restyled may pick up changes that have been made to the default`,
+        `branch since you created this branch.`,
+      ].join(" "),
     );
   }
 

--- a/run/src/suggestions.ts
+++ b/run/src/suggestions.ts
@@ -16,6 +16,7 @@
 import { type ParsedPatchType } from "parse-git-patch";
 
 import { Hunks } from "./hunk";
+import { ChangedFile } from "./diff";
 import * as NE from "./non-empty";
 
 export type Suggestion = {
@@ -28,16 +29,15 @@ export type Suggestion = {
 };
 
 export function getSuggestions(
-  bases: ParsedPatchType[],
+  baseFiles: ChangedFile[],
   patches: ParsedPatchType[],
   resolved: Suggestion[],
 ): Suggestion[] {
   const suggestions: Suggestion[] = [];
-  const baseFiles = bases.flatMap((p) => p.files);
 
   patches.forEach((patch) => {
     patch.files.forEach((file) => {
-      const baseFile = baseFiles.find((x) => x.afterName === file.afterName);
+      const baseFile = baseFiles.find((x) => x.filename === file.afterName);
 
       if (!baseFile) {
         suggestions.push({
@@ -51,7 +51,7 @@ export function getSuggestions(
         return;
       }
 
-      const baseAdds = new Hunks(baseFile.modifiedLines.filter((x) => x.added));
+      const baseAdds = baseFile.additions;
       const dels = new Hunks(file.modifiedLines.filter((x) => !x.added));
       const adds = new Hunks(file.modifiedLines.filter((x) => x.added));
 


### PR DESCRIPTION
This fails for large PRs, and the `/files` response we already have
contains enough of the diff details to do what we need, which is confirm
that our restyled are contained within added lines of the original PR.

To do this, we introduce a `ChangeFile` type that we can build from the
`/files` response. It can hold hunks of added lines, so we can do our
`.contains` check with it.

It even reads better this way,

```js
changedFile.additions.contain(_)
```

:ok_hand: