### PR TITLE
Add suggestions-limit input and unapplied-suggestions output

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ jobs:
           suggestions: true
 ```
 
+See also: `inputs.suggestions-limit`, `outputs.suggestions-skipped`.
+
 ### Upload Patch Artifact
 
 **Good for**: users who are not using _Code Suggestion Comments_ and expect

--- a/run/README.md
+++ b/run/README.md
@@ -27,6 +27,12 @@ Run the restyle CLI on changed files in a PR
     # Required: false
     # Default: false
 
+    suggestion-limit:
+    # Limit the number of suggestion comments left
+    #
+    # Required: false
+    # Default: ""
+
     show-patch:
     # Log the patch produced by Restyled with git format-patch
     #
@@ -106,6 +112,7 @@ Run the restyle CLI on changed files in a PR
 | `paths`               | <p>New-line separated paths to restyle, default is paths changed in the PR</p>           | `false`  | `""`                  |
 | `github-token`        | <p>Token used to query for PR details</p>                                                | `false`  | `${{ github.token }}` |
 | `suggestions`         | <p>Add suggestion comments of restyled changes</p>                                       | `false`  | `false`               |
+| `suggestion-limit`    | <p>Limit the number of suggestion comments left</p>                                      | `false`  | `""`                  |
 | `show-patch`          | <p>Log the patch produced by Restyled with git format-patch</p>                          | `false`  | `true`                |
 | `show-patch-command`  | <p>Log a copy/paste-able command to apply the patch produced by Restyled with git-am</p> | `false`  | `true`                |
 | `committer-email`     | <p>Email used for Restyled commits</p>                                                   | `false`  | `commits@restyled.io` |
@@ -124,14 +131,15 @@ Run the restyle CLI on changed files in a PR
 
 ## Outputs
 
-| name             | description                                                                            |
-| ---------------- | -------------------------------------------------------------------------------------- |
-| `success`        | <p><code>true</code> if <code>restyle</code> ran successfully (differences or not)</p> |
-| `differences`    | <p><code>true</code> if differences were created by restyling</p>                      |
-| `git-patch`      | <p>The restyle commits, formatted for use with <code>git am</code></p>                 |
-| `restyled-base`  | <p>The base branch to use if opening fixes as a new PR</p>                             |
-| `restyled-head`  | <p>The head branch to use if opening fixes as a new PR </p>                            |
-| `restyled-title` | <p>The title to use if opening fixes as a new PR</p>                                   |
-| `restyled-body`  | <p>The body to use if opening fixes as a new PR</p>                                    |
+| name                  | description                                                                            |
+| --------------------- | -------------------------------------------------------------------------------------- |
+| `success`             | <p><code>true</code> if <code>restyle</code> ran successfully (differences or not)</p> |
+| `differences`         | <p><code>true</code> if differences were created by restyling</p>                      |
+| `git-patch`           | <p>The restyle commits, formatted for use with <code>git am</code></p>                 |
+| `restyled-base`       | <p>The base branch to use if opening fixes as a new PR</p>                             |
+| `restyled-head`       | <p>The head branch to use if opening fixes as a new PR </p>                            |
+| `restyled-title`      | <p>The title to use if opening fixes as a new PR</p>                                   |
+| `restyled-body`       | <p>The body to use if opening fixes as a new PR</p>                                    |
+| `suggestions-skipped` | <p>True if there were suggestions we had to skip</p>                                   |
 
 <!-- action-docs-outputs source="action.yml" -->

--- a/run/action.yml
+++ b/run/action.yml
@@ -67,6 +67,8 @@ outputs:
     description: "The title to use if opening fixes as a new PR"
   restyled-body:
     description: "The body to use if opening fixes as a new PR"
+  suggestions-skipped:
+    description: "True if there were suggestions we had to skip"
 
 runs:
   using: "node20"

--- a/run/action.yml
+++ b/run/action.yml
@@ -13,6 +13,9 @@ inputs:
   suggestions:
     description: "Add suggestion comments of restyled changes"
     default: false
+  suggestion-limit:
+    description: "Limit the number of suggestion comments left"
+    required: false
   show-patch:
     description: "Log the patch produced by Restyled with git format-patch"
     default: true

--- a/run/src/inputs.ts
+++ b/run/src/inputs.ts
@@ -20,6 +20,7 @@ export type Inputs = {
   paths: string[];
   githubToken: string;
   suggestions: boolean;
+  suggestionsLimit: number | null;
   showPatch: boolean;
   showPatchCommand: boolean;
   committerEmail: string;
@@ -44,12 +45,20 @@ export function getInputs(): Inputs {
     }
   }
 
+  const rawSuggestionLimit = core.getInput("suggestion-limit", {
+    required: false,
+  });
+
   return {
     paths,
     githubToken: core.getInput("github-token", { required: true }),
     suggestions: core.getBooleanInput("suggestions", {
       required: true,
     }),
+    suggestionsLimit:
+      rawSuggestionLimit && rawSuggestionLimit !== ""
+        ? parseInt(rawSuggestionLimit, 10)
+        : null,
     showPatch: core.getBooleanInput("show-patch", {
       required: true,
     }),

--- a/run/src/main.ts
+++ b/run/src/main.ts
@@ -106,13 +106,20 @@ async function run() {
 
         let n = 0;
         const ps = suggestions.map((s) => {
-          if (s.skipReason) {
+          const limitSkipReason =
+            inputs.suggestionsLimit && n >= inputs.suggestionsLimit
+              ? "limit reached"
+              : null;
+
+          const skipReason = s.skipReason ?? limitSkipReason;
+
+          if (skipReason) {
             const line =
               s.startLine !== s.endLine
                 ? `${s.startLine}-${s.endLine}`
                 : `${s.startLine}`;
             const location = `${s.path}:${line}`;
-            core.warning(`[${location}]: Skipping suggestion: ${s.skipReason}`);
+            core.warning(`[${location}]: Skipping suggestion: ${skipReason}`);
             return Promise.resolve();
           } else {
             n += 1;

--- a/run/src/main.ts
+++ b/run/src/main.ts
@@ -98,6 +98,8 @@ async function run() {
       core.info("  ");
     }
 
+    let suggestionsSkipped = false;
+
     if (inputs.suggestions && success) {
       const resolved = await clearPriorSuggestions(client, pr);
 
@@ -120,6 +122,7 @@ async function run() {
                 : `${s.startLine}`;
             const location = `${s.path}:${line}`;
             core.warning(`[${location}]: Skipping suggestion: ${skipReason}`);
+            suggestionsSkipped = true;
             return Promise.resolve();
           } else {
             n += 1;
@@ -140,6 +143,7 @@ async function run() {
       restyledHead: `restyled/${pr.headRef}`,
       restyledTitle: `Restyled ${pr.title}`,
       restyledBody: pullRequestDescription(pr.number),
+      suggestionsSkipped,
     });
 
     if (ec !== 0) {

--- a/run/src/outputs.ts
+++ b/run/src/outputs.ts
@@ -23,6 +23,7 @@ export type Outputs = {
   restyledHead: string;
   restyledTitle: string;
   restyledBody: string;
+  suggestionsSkipped: boolean;
 };
 
 export function setOutputs(outputs: Outputs): void {
@@ -33,4 +34,5 @@ export function setOutputs(outputs: Outputs): void {
   core.setOutput("restyled-head", outputs.restyledHead);
   core.setOutput("restyled-title", outputs.restyledTitle);
   core.setOutput("restyled-body", outputs.restyledBody);
+  core.setOutput("suggestions-skipped", outputs.suggestionsSkipped);
 }


### PR DESCRIPTION
This PR addresses two things:

1- Suggestions might not always be able to be applied. If the suggestion is not on a line added in the PR, GitHub will refuse the comment. Most of the time, this is OK. Ignoring a Restyled fix on something you didn't change in the PR is generally an acceptable (and often preferred) behavior. However, at least the case of sorting inputs is a problem. When inputs are sorted, Restyled may want to suggest removal of an added import line (which will show up) and addition of that import line elsewhere, which will not. In this case, you're not just ignoring an irrelevant fix, you're seeing half a fix and it's incoherent.

2- Opening a particularly unstyled PR and receiving 50+ comments is a bad experience. If folks are using the suggestions workflow, it's because they expect few style issues at a time.

The `suggestions-limit` input can now be used to avoid (2). Along with (1), this means there are more cases where suggestions are not applied that our users probably don't want to ignore. For that, we added the `suggestions-skipped` _output_ so users can check for when this happens and take action.

```yaml
- if: steps.restyled.outputs.suggestions-skipped == 'true'
  # ...
```