### PR TITLE
feat: add no-clean, explicitly pass positive options

### DIFF
--- a/run/action.yml
+++ b/run/action.yml
@@ -48,6 +48,9 @@ inputs:
   no-commit:
     description: "Pass `--no-commit` to `restyle`"
     default: false
+  no-clean:
+    description: "Pass `--no-clean` to `restyle`"
+    default: false
   no-pull:
     description: "Pass `--no-pull` to `restyle`"
     default: false

--- a/run/dist/index.js
+++ b/run/dist/index.js
@@ -119,18 +119,23 @@ function getInputs() {
         imageCleanup: core.getBooleanInput("image-cleanup", { required: true }),
         manifest: core.getInput("manifest", { required: false }),
         noCommit: core.getBooleanInput("no-commit", { required: true }),
+        noClean: core.getBooleanInput("no-clean", { required: true }),
         noPull: core.getBooleanInput("no-pull", { required: true }),
     };
 }
 function cliArguments(inputs) {
     return []
         .concat(inputs.debug ? ["--debug"] : [])
-        .concat(inputs.failOnDifferences ? ["--fail-on-differences"] : [])
-        .concat(inputs.imageCleanup ? ["--image-cleanup"] : [])
         .concat(inputs.manifest !== "" ? ["--manifest", inputs.manifest] : [])
-        .concat(inputs.dryRun ? ["--dry-run"] : [])
-        .concat(inputs.noCommit ? ["--no-commit"] : [])
-        .concat(inputs.noPull ? ["--no-pull"] : []);
+        .concat(yesNo(inputs.failOnDifferences, "fail-on-differences"))
+        .concat(yesNo(inputs.imageCleanup, "image-cleanup"))
+        .concat(yesNo(inputs.dryRun, "dry-run"))
+        .concat(yesNo(!inputs.noCommit, "commit"))
+        .concat(yesNo(!inputs.noClean, "clean"))
+        .concat(yesNo(!inputs.noPull, "pull"));
+}
+function yesNo(p, name) {
+    return p ? [`--${name}`] : [`--no-${name}`];
 }
 
 

--- a/run/src/inputs.ts
+++ b/run/src/inputs.ts
@@ -84,11 +84,15 @@ export function getInputs(): Inputs {
 export function cliArguments(inputs: Inputs): string[] {
   return ([] as string[])
     .concat(inputs.debug ? ["--debug"] : [])
-    .concat(inputs.failOnDifferences ? ["--fail-on-differences"] : [])
-    .concat(inputs.imageCleanup ? ["--image-cleanup"] : [])
     .concat(inputs.manifest !== "" ? ["--manifest", inputs.manifest] : [])
-    .concat(inputs.dryRun ? ["--dry-run"] : [])
-    .concat(inputs.noCommit ? ["--no-commit"] : ["--commit"])
-    .concat(inputs.noClean ? ["--no-clean"] : ["--clean"])
-    .concat(inputs.noPull ? ["--no-pull"] : ["--pull"]);
+    .concat(yesNo(inputs.failOnDifferences, "fail-on-differences"))
+    .concat(yesNo(inputs.imageCleanup, "image-cleanup"))
+    .concat(yesNo(inputs.dryRun, "dry-run"))
+    .concat(yesNo(!inputs.noCommit, "commit"))
+    .concat(yesNo(!inputs.noClean, "clean"))
+    .concat(yesNo(!inputs.noPull, "pull"));
+}
+
+function yesNo(p: boolean, name: string): string[] {
+  return p ? [`--${name}`] : [`--no-${name}`];
 }

--- a/run/src/inputs.ts
+++ b/run/src/inputs.ts
@@ -31,6 +31,7 @@ export type Inputs = {
   imageCleanup: boolean;
   manifest: string;
   noCommit: boolean;
+  noClean: boolean;
   noPull: boolean;
 };
 
@@ -75,6 +76,7 @@ export function getInputs(): Inputs {
     imageCleanup: core.getBooleanInput("image-cleanup", { required: true }),
     manifest: core.getInput("manifest", { required: false }),
     noCommit: core.getBooleanInput("no-commit", { required: true }),
+    noClean: core.getBooleanInput("no-clean", { required: true }),
     noPull: core.getBooleanInput("no-pull", { required: true }),
   };
 }
@@ -86,6 +88,7 @@ export function cliArguments(inputs: Inputs): string[] {
     .concat(inputs.imageCleanup ? ["--image-cleanup"] : [])
     .concat(inputs.manifest !== "" ? ["--manifest", inputs.manifest] : [])
     .concat(inputs.dryRun ? ["--dry-run"] : [])
-    .concat(inputs.noCommit ? ["--no-commit"] : [])
-    .concat(inputs.noPull ? ["--no-pull"] : []);
+    .concat(inputs.noCommit ? ["--no-commit"] : ["--commit"])
+    .concat(inputs.noClean ? ["--no-clean"] : ["--clean"])
+    .concat(inputs.noPull ? ["--no-pull"] : ["--pull"]);
 }


### PR DESCRIPTION
### [feat: add no-clean, explicitly pass positive options](https://github.com/restyled-io/actions/pull/278/commits/e9cdf988462d378c6426e547ceea1f8646cc411c)

We're going to change the CLI defaults for the commit and clean options,
so that locally it doesn't commit or clean by default. By explicitly
passing the positive versions now, the behavior when run as an action
will not change when that happens.

### [chore: extract yesNo argument helper](https://github.com/restyled-io/actions/pull/278/commits/746bebaa844713c869e8fba140751dd5a67eb093)



### [chore: build](https://github.com/restyled-io/actions/pull/278/commits/59d97f5907b69689f9f48110fd2d9dfa87ce51aa)



