### PR TITLE
fix(setup): refactor, don't rely on gh

### DIFF
--- a/setup/action.yml
+++ b/setup/action.yml
@@ -30,41 +30,7 @@ runs:
   using: composite
   steps:
     - shell: bash
-      run: |
-        gh_release() {
-          gh --repo restyled-io/restyler release "$@"
-        }
-
-        cp_v() {
-          if ((UID)): then
-            sudo cp -v "$@"
-          else
-            cp -v "$@"
-          fi
-        }
-
-        os=$(uname -s | tr '[:upper:]' '[:lower:]')
-        arch=$(uname -m)
-        dir=restyler-$os-$arch
-        ext=tar.gz
-        tag=$TAG
-
-        if [[ -z "$tag" ]]; then
-          tag=$(gh_release view --json tagName --jq '.tagName')
-        fi
-
-        printf 'Release artifact %s/%s.%s\n' "$tag" "$dir" "$ext"
-
-        gh_release download "$TAG" --pattern "$dir.$ext" --output - |
-          tar xzf -
-
-        for bin in "$dir"/*; do
-          if [ -x "$bin" ]; then
-            cp_v "$bin" /usr/local/bin/
-          fi
-        done
-
-        rm -rf "$dir"
+      run: 'exec "$GITHUB_ACTION_PATH"/bin/setup'
       env:
         GH_TOKEN: ${{ inputs.github-token }}
         TAG: ${{ inputs.tag }}

--- a/setup/bin/setup
+++ b/setup/bin/setup
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Copyright (C) 2025 Patrick Brisbin
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+set -euo pipefail
+
+curl_() {
+  curl --silent --fail --location "$@"
+}
+
+get_latest_tag_name() {
+  curl_ -H 'accept: application/json' "$REPO/releases/latest" |
+    jq -r '.tag_name'
+}
+
+cp_v() {
+  if ((UID)); then
+    sudo cp -v "$@"
+  else
+    cp -v "$@"
+  fi
+}
+
+: "${REPO:=https://github.com/restyled-io/restyler}"
+: "${OS:=$(uname -s | tr '[:upper:]' '[:lower:]')}"
+: "${ARCH:=$(uname -m)}"
+: "${TAG:=$(get_latest_tag_name)}"
+
+dir="restyler-$OS-$ARCH"
+tgz="$dir.tar.gz"
+artifact="$REPO/releases/download/$TAG/$tgz"
+
+printf "Download: %s\n" "$artifact"
+curl_ "$artifact" | tar xzf -
+
+for bin in "$dir"/*; do
+  if [ -x "$bin" ]; then
+    cp_v "$bin" /usr/local/bin/
+  fi
+done
+
+rm -rf "$dir"


### PR DESCRIPTION
### [fix(setup): don't use sudo if root](https://github.com/restyled-io/actions/pull/313/commits/3642007f7983c8e22651a9aab008f6b4f234d01e) 
[3642007](https://github.com/restyled-io/actions/pull/313/commits/3642007f7983c8e22651a9aab008f6b4f234d01e)

### [fix(setup): refactor, don't rely on gh](https://github.com/restyled-io/actions/pull/313/commits/6aa99584010b2dd463509d3b719f244ae9775dcf) 
[6aa9958](https://github.com/restyled-io/actions/pull/313/commits/6aa99584010b2dd463509d3b719f244ae9775dcf)
* Extract to separate script file
* Refactor env-handling
* Replace `gh` calls with `curl`